### PR TITLE
add standalone jw player adapter and api logic

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -25,5 +25,5 @@ jobs:
         uses: alleyinteractive/action-test-php@develop
         with:
           php-version: ${{ matrix.php-version }}
-          wordpress-host: 'false'
-          wordpress-version: 'false'
+          wordpress-version: 'latest'
+          skip-wordpress-install: 'true'

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ use DateInterval;
 use DateTimeImmutable;
 use WP_Query;
 
-add_action( 'plugins_loaded', function () => {
+add_action( 'plugins_loaded', function () {
 	$sync_manager = Sync_Manager::init()
 		->with_adapter( new JW_Player_7_For_WP() )
 		->with_frequency( 'hourly' )

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,8 +16,7 @@
     </testsuite>
   </testsuites>
   <php>
-    <!-- <env name="MANTLE_USE_SQLITE" value="true" /> -->
-    <!-- <env name="WP_SKIP_DB_CREATE" value="true" /> -->
-    <const name="MANTLE_TESTING_DEBUG" value="true" />
+    <env name="MANTLE_USE_SQLITE" value="true" />
+    <env name="WP_SKIP_DB_CREATE" value="true" />
   </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,7 +16,8 @@
     </testsuite>
   </testsuites>
   <php>
-    <env name="MANTLE_USE_SQLITE" value="true" />
-    <env name="WP_SKIP_DB_CREATE" value="true" />
+    <!-- <env name="MANTLE_USE_SQLITE" value="true" /> -->
+    <!-- <env name="WP_SKIP_DB_CREATE" value="true" /> -->
+    <const name="MANTLE_TESTING_DEBUG" value="true" />
   </php>
 </phpunit>

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -1,0 +1,28 @@
+## Class JW_Player
+
+This class will implement the base `Adapter` interface. Instantiating this class with a `JW_Player_API` object will allow the request to be made to get the latest videos to be synced. This class may be used to work with a theme's custom integration with JW Player.
+
+Example Integration:
+
+```shell
+\Alley\WP\WP_Video_Sync\Sync_Manager::init()
+	->with_adapter(
+		new \Alley\WP\WP_Video_Sync\Adapters\JW_Player(
+			new \Alley\WP\WP_Video_Sync\API\JW_Player_API(
+				[PROPERTY_ID],
+				[API_KEY]
+			)
+		)
+	)
+	->with_batch_size()
+	->with_frequency()
+	->with_callback(
+		function ( $video ) {
+			// Do something with the video.
+		}
+);
+```
+
+## Class JW_Player_7_For_WP
+
+This class is to work with the JW Player 7 for WordPress plugin.

--- a/src/adapters/class-jw-player-7-for-wp.php
+++ b/src/adapters/class-jw-player-7-for-wp.php
@@ -40,7 +40,10 @@ class JW_Player_7_For_WP extends Last_Modified_Date implements Adapter {
 
 			// Attempt to set the last modified date.
 			if ( isset( $videos[ count( $videos ) - 1 ]->last_modified ) ) {
-				$this->set_last_modified_date( $videos[ count( $videos ) - 1 ]->last_modified );
+				$last_modified_date = DateTimeImmutable::createFromFormat( DATE_W3C, $videos[ count( $videos ) - 1 ]->last_modified );
+				if ( $last_modified_date instanceof DateTimeImmutable ) {
+					$this->set_last_modified_date( $last_modified_date );
+				}
 			}
 
 			return $videos;

--- a/src/adapters/class-jw-player-7-for-wp.php
+++ b/src/adapters/class-jw-player-7-for-wp.php
@@ -8,28 +8,14 @@
 namespace Alley\WP\WP_Video_Sync\Adapters;
 
 use Alley\WP\WP_Video_Sync\Interfaces\Adapter;
+use Alley\WP\WP_Video_Sync\Last_Modified_Date;
 use DateTimeImmutable;
 use stdClass;
 
 /**
  * JW Player 7 for WP Adapter. Supports both the free and premium versions of the plugin.
  */
-class JW_Player_7_For_WP implements Adapter {
-	/**
-	 * The date of the last modification to the last batch of videos.
-	 *
-	 * @var ?DateTimeImmutable
-	 */
-	private ?DateTimeImmutable $last_modified_date;
-
-	/**
-	 * Fetches the date of the last modification to the last batch of videos.
-	 *
-	 * @return ?DateTimeImmutable
-	 */
-	public function get_last_modified_date(): ?DateTimeImmutable {
-		return $this->last_modified_date;
-	}
+class JW_Player_7_For_WP extends Last_Modified_Date implements Adapter {
 
 	/**
 	 * Fetches videos from JW Player that were modified after the provided DateTime.
@@ -54,10 +40,7 @@ class JW_Player_7_For_WP implements Adapter {
 
 			// Attempt to set the last modified date.
 			if ( isset( $videos[ count( $videos ) - 1 ]->last_modified ) ) {
-				$last_modified_date = DateTimeImmutable::createFromFormat( DATE_W3C, $videos[ count( $videos ) - 1 ]->last_modified );
-				if ( $last_modified_date instanceof DateTimeImmutable ) {
-					$this->last_modified_date = $last_modified_date;
-				}
+				$this->set_last_modified_date( $videos[ count( $videos ) - 1 ]->last_modified );
 			}
 
 			return $videos;

--- a/src/adapters/class-jw-player.php
+++ b/src/adapters/class-jw-player.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * WP Video Sync: JW Player Adapter.
+ *
+ * @package wp-video-sync
+ */
+
+namespace Alley\WP\WP_Video_Sync\Adapters;
+
+use Alley\WP\WP_Video_Sync\API\JW_Player_API;
+use Alley\WP\WP_Video_Sync\Interfaces\Adapter;
+use DateTimeImmutable;
+use stdClass;
+
+/**
+ * JW Player Adapter.
+ */
+class JW_Player implements Adapter {
+
+	/**
+	 * The date of the last modification to the last batch of videos.
+	 *
+	 * @var ?DateTimeImmutable
+	 */
+	private ?DateTimeImmutable $last_modified_date;
+
+	/**
+	 * The JW Player API.
+	 *
+	 * @var JW_Player_API
+	 */
+	public JW_Player_API $jw_player_api;
+
+	/**
+	 * The start date if the `last_modified_date` does not exist.
+	 *
+	 * @var string
+	 */
+	public string $origin_modified_date;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param JW_Player_API $api Instance of the JW Player API object.
+	 * @param string        $origin_modified_date The date of the used if the `last_modified_date` does not exist.
+	 */
+	public function __construct( JW_Player_API $api, string $origin_modified_date = '' ) {
+		$this->jw_player_api        = $api;
+		$this->origin_modified_date = ! empty( $origin_modified_date ) ? $origin_modified_date : date( 'Y-m-d' );
+	}
+
+	/**
+	 * Fetches the date of the last modification to the last batch of videos.
+	 *
+	 * @return ?DateTimeImmutable
+	 */
+	public function get_last_modified_date(): ?DateTimeImmutable {
+		return $this->last_modified_date ?? DateTimeImmutable::createFromFormat('Y-m-d', $this->origin_modified_date );
+	}
+
+	/**
+	 * Sets the date of the last modification to the latest batch of videos.
+	 *
+	 * @param array $videos An array of videos and associated data.
+	 * @return void
+	 */
+	public function set_last_modified_date( array $videos ): void {
+		if (
+			! empty( $videos )
+			&& isset( $videos[ count( $videos ) - 1 ]->last_modified )
+		) {
+			$last_modified_date = DateTimeImmutable::createFromFormat( DATE_W3C, $videos[ count( $videos ) - 1 ]->last_modified );
+
+			if ( $last_modified_date instanceof DateTimeImmutable ) {
+				$this->last_modified_date = $last_modified_date;
+			}
+		}
+	}
+
+	/**
+	 * Fetches videos from JW Player that were modified after the provided DateTime.
+	 *
+	 * @param DateTimeImmutable $updated_after Return videos modified after this date.
+	 * @param int               $batch_size    The number of videos to fetch in each batch.
+	 *
+	 * @return stdClass[] An array of video data.
+	 */
+	public function get_videos( DateTimeImmutable $updated_after, int $batch_size ): array {
+		// Get the latest videos from JW Player.
+		$videos = $this->jw_player_api->request_latest_videos(
+			$updated_after->format( 'Y-m-d' ),
+			$batch_size
+		);
+
+		// Check for an API error.
+		if ( ! empty( $videos['error'] ) ) {
+			return [];
+		}
+
+		// Attempt to set the last modified date.
+		$this->set_last_modified_date( $videos );
+
+		// Return the videos.
+		return ! empty( $videos ) ? $videos : [];
+	}
+}

--- a/src/adapters/class-jw-player.php
+++ b/src/adapters/class-jw-player.php
@@ -10,20 +10,14 @@ namespace Alley\WP\WP_Video_Sync\Adapters;
 use Alley\WP\WP_Video_Sync\API\JW_Player_API;
 use Alley\WP\WP_Video_Sync\API\Request;
 use Alley\WP\WP_Video_Sync\Interfaces\Adapter;
+use Alley\WP\WP_Video_Sync\Last_Modified_Date;
 use DateTimeImmutable;
 use stdClass;
 
 /**
  * JW Player Adapter.
  */
-class JW_Player implements Adapter {
-
-	/**
-	 * The date of the last modification to the last batch of videos.
-	 *
-	 * @var ?DateTimeImmutable
-	 */
-	private ?DateTimeImmutable $last_modified_date = null;
+class JW_Player extends Last_Modified_Date implements Adapter {
 
 	/**
 	 * The JW Player API.
@@ -39,34 +33,6 @@ class JW_Player implements Adapter {
 	 */
 	public function __construct( JW_Player_API $api ) {
 		$this->jw_player_api = $api;
-	}
-
-	/**
-	 * Fetches the date of the last modification to the last batch of videos.
-	 *
-	 * @return ?DateTimeImmutable
-	 */
-	public function get_last_modified_date(): ?DateTimeImmutable {
-		return $this->last_modified_date;
-	}
-
-	/**
-	 * Sets the date of the last modification to the latest batch of videos.
-	 *
-	 * @param array $videos An array of videos and associated data.
-	 * @return void
-	 */
-	public function set_last_modified_date( array $videos ): void {
-		if (
-			! empty( $videos )
-			&& isset( $videos[ count( $videos ) - 1 ]->last_modified )
-		) {
-			$last_modified_date = DateTimeImmutable::createFromFormat( DATE_W3C, $videos[ count( $videos ) - 1 ]->last_modified );
-
-			if ( $last_modified_date instanceof DateTimeImmutable ) {
-				$this->last_modified_date = $last_modified_date;
-			}
-		}
 	}
 
 	/**
@@ -93,7 +59,12 @@ class JW_Player implements Adapter {
 		}
 
 		// Attempt to set the last modified date.
-		$this->set_last_modified_date( $videos['media'] );
+		if (
+			! empty( $videos['media'] )
+			&& isset( $videos['media'][ count( $videos['media'] ) - 1 ]->last_modified )
+		) {
+			$this->set_last_modified_date( $videos['media'][ count( $videos ) - 1 ]->last_modified );
+		}
 
 		// Return the videos.
 		return ! empty( $videos['media'] ) ? $videos['media'] : [];

--- a/src/adapters/class-jw-player.php
+++ b/src/adapters/class-jw-player.php
@@ -8,6 +8,7 @@
 namespace Alley\WP\WP_Video_Sync\Adapters;
 
 use Alley\WP\WP_Video_Sync\API\JW_Player_API;
+use Alley\WP\WP_Video_Sync\API\Request;
 use Alley\WP\WP_Video_Sync\Interfaces\Adapter;
 use DateTimeImmutable;
 use stdClass;
@@ -77,11 +78,14 @@ class JW_Player implements Adapter {
 	 * @return stdClass[] An array of video data.
 	 */
 	public function get_videos( DateTimeImmutable $updated_after, int $batch_size ): array {
-		// Get the latest videos from JW Player.
-		$videos = $this->jw_player_api->request_latest_videos(
+		// Set the request URL based on the arguments.
+		$this->jw_player_api->set_request_url(
 			$updated_after->format( 'Y-m-d' ),
 			$batch_size
 		);
+
+		// Perform the request.
+		$videos = ( new Request( $this->jw_player_api ) )->get();
 
 		// Check for an API error.
 		if ( ! empty( $videos['error'] ) ) {
@@ -89,9 +93,9 @@ class JW_Player implements Adapter {
 		}
 
 		// Attempt to set the last modified date.
-		$this->set_last_modified_date( $videos );
+		$this->set_last_modified_date( $videos['media'] );
 
 		// Return the videos.
-		return ! empty( $videos ) ? $videos : [];
+		return ! empty( $videos['media'] ) ? $videos['media'] : [];
 	}
 }

--- a/src/adapters/class-jw-player.php
+++ b/src/adapters/class-jw-player.php
@@ -19,20 +19,11 @@ use DateTimeImmutable;
 class JW_Player extends Last_Modified_Date implements Adapter {
 
 	/**
-	 * The JW Player API.
-	 *
-	 * @var JW_Player_API
-	 */
-	public JW_Player_API $jw_player_api;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param JW_Player_API $api Instance of the JW Player API object.
+	 * @param JW_Player_API $jw_player_api Instance of the JW Player API object.
 	 */
-	public function __construct( JW_Player_API $api ) {
-		$this->jw_player_api = $api;
-	}
+	public function __construct( public readonly JW_Player_API $jw_player_api ) {}
 
 	/**
 	 * Fetches videos from JW Player that were modified after the provided DateTime.

--- a/src/adapters/class-jw-player.php
+++ b/src/adapters/class-jw-player.php
@@ -22,7 +22,7 @@ class JW_Player implements Adapter {
 	 *
 	 * @var ?DateTimeImmutable
 	 */
-	private ?DateTimeImmutable $last_modified_date;
+	private ?DateTimeImmutable $last_modified_date = null;
 
 	/**
 	 * The JW Player API.

--- a/src/adapters/class-jw-player.php
+++ b/src/adapters/class-jw-player.php
@@ -12,7 +12,6 @@ use Alley\WP\WP_Video_Sync\API\Request;
 use Alley\WP\WP_Video_Sync\Interfaces\Adapter;
 use Alley\WP\WP_Video_Sync\Last_Modified_Date;
 use DateTimeImmutable;
-use stdClass;
 
 /**
  * JW Player Adapter.
@@ -41,7 +40,7 @@ class JW_Player extends Last_Modified_Date implements Adapter {
 	 * @param DateTimeImmutable $updated_after Return videos modified after this date.
 	 * @param int               $batch_size    The number of videos to fetch in each batch.
 	 *
-	 * @return stdClass[] An array of video data.
+	 * @return array<mixed> An array of video data objects.
 	 */
 	public function get_videos( DateTimeImmutable $updated_after, int $batch_size ): array {
 		// Set the request URL based on the arguments.
@@ -58,9 +57,14 @@ class JW_Player extends Last_Modified_Date implements Adapter {
 			return [];
 		}
 
+		// Validate the media property.
+		if ( ! is_array( $videos['media'] ) ) {
+			return [];
+		}
+
 		// Attempt to set the last modified date.
 		if (
-			! empty( $videos['media'] )
+			! empty( $videos['media'][ count( $videos['media'] ) - 1 ] )
 			&& isset( $videos['media'][ count( $videos['media'] ) - 1 ]->last_modified )
 		) {
 			$this->set_last_modified_date( $videos['media'][ count( $videos ) - 1 ]->last_modified );

--- a/src/adapters/class-jw-player.php
+++ b/src/adapters/class-jw-player.php
@@ -32,21 +32,12 @@ class JW_Player implements Adapter {
 	public JW_Player_API $jw_player_api;
 
 	/**
-	 * The start date if the `last_modified_date` does not exist.
-	 *
-	 * @var string
-	 */
-	public string $origin_modified_date;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param JW_Player_API $api Instance of the JW Player API object.
-	 * @param string        $origin_modified_date The date of the used if the `last_modified_date` does not exist.
 	 */
-	public function __construct( JW_Player_API $api, string $origin_modified_date = '' ) {
-		$this->jw_player_api        = $api;
-		$this->origin_modified_date = ! empty( $origin_modified_date ) ? $origin_modified_date : date( 'Y-m-d' );
+	public function __construct( JW_Player_API $api ) {
+		$this->jw_player_api = $api;
 	}
 
 	/**
@@ -55,7 +46,7 @@ class JW_Player implements Adapter {
 	 * @return ?DateTimeImmutable
 	 */
 	public function get_last_modified_date(): ?DateTimeImmutable {
-		return $this->last_modified_date ?? DateTimeImmutable::createFromFormat('Y-m-d', $this->origin_modified_date );
+		return $this->last_modified_date;
 	}
 
 	/**

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,7 @@
+## Class JW_Player_API
+
+This class is used for constructing an object for making an API call to the JW Player API. Simply pass your API key and API Secret on instantiation. Please reference the interface `API_Requester` for the required methods. This object may be used to pass to the `JW_Player` adapter.
+
+## Class Request
+
+This class will handle the generation of the URL for performing an API request. The API response will call the `parse_response` method which will subsequently call the `parse_success()` or `parse_error()` method of the `API_Requester` object that is used to construct this object.

--- a/src/api/class-jw-player-api.php
+++ b/src/api/class-jw-player-api.php
@@ -105,7 +105,7 @@ class JW_Player_API implements API_Requester {
 	 */
 	public function parse_error( array $response_object ): array {
 		return ! empty( $response_object['errors'] )
-			&& is_array($response_object['errors'] )
+			&& is_array( $response_object['errors'] )
 			&& isset( $response_object['errors'][0]->description )
 			? [ 'error' => $response_object['errors'][0]->description ]
 			: [];

--- a/src/api/class-jw-player-api.php
+++ b/src/api/class-jw-player-api.php
@@ -22,20 +22,6 @@ class JW_Player_API implements API_Requester {
 	public string $api_url = 'https://api.jwplayer.com/v2/sites';
 
 	/**
-	 * The API public key.
-	 *
-	 * @var string
-	 */
-	public string $api_key;
-
-	/**
-	 * The API v2 secret key.
-	 *
-	 * @var string
-	 */
-	public string $api_secret;
-
-	/**
 	 * The request URL.
 	 *
 	 * @var string
@@ -46,12 +32,12 @@ class JW_Player_API implements API_Requester {
 	 * Constructor.
 	 *
 	 * @param string $api_key The API key.
-	 * @param string $api_secret The API secret.
+	 * @param string $api_secret The API v2 secret key.
 	 */
-	public function __construct( string $api_key, string $api_secret ) {
-		$this->api_key    = $api_key;
-		$this->api_secret = $api_secret;
-	}
+	public function __construct(
+		public readonly string $api_key,
+		public readonly string $api_secret
+	) {}
 
 	/**
 	 * Generate the request URL.

--- a/src/api/class-jw-player-api.php
+++ b/src/api/class-jw-player-api.php
@@ -59,7 +59,7 @@ class JW_Player_API implements API_Requester {
 	 * @param string $last_modified_date The date of the last modification to the last batch of videos.
 	 * @param int    $batch_size         The number of videos to fetch in each batch.
 	 */
-	public function set_request_url( string $last_modified_date, int $batch_size ) {
+	public function set_request_url( string $last_modified_date, int $batch_size ): void {
 		$request_url = $this->api_url . '/' . $this->api_key . '/media/';
 
 		$this->request_url = add_query_arg(
@@ -85,7 +85,7 @@ class JW_Player_API implements API_Requester {
 	/**
 	 * Get the request arguments.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string>>
 	 */
 	public function get_request_args(): array {
 		return [
@@ -99,12 +99,14 @@ class JW_Player_API implements API_Requester {
 	/**
 	 * Parse the API error response.
 	 *
-	 * @param array $response_object The API response object.
+	 * @param array<mixed> $response_object The API response object.
 	 *
-	 * @return array
+	 * @return array<string, string>
 	 */
 	public function parse_error( array $response_object ): array {
-		return isset( $response_object['errors'][0]->description )
+		return ! empty( $response_object['errors'] )
+			&& is_array($response_object['errors'] )
+			&& isset( $response_object['errors'][0]->description )
 			? [ 'error' => $response_object['errors'][0]->description ]
 			: [];
 	}
@@ -112,12 +114,13 @@ class JW_Player_API implements API_Requester {
 	/**
 	 * Parse the API successful response.
 	 *
-	 * @param array $response_object The API response object.
+	 * @param array<mixed> $response_object The API response object.
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	public function parse_success( array $response_object ): array {
-		return is_array( $response_object['media'] ) && ! empty( $response_object['media'] )
+		return ! empty( $response_object['media'] )
+			&& is_array( $response_object['media'] )
 			? [ 'media' => $response_object['media'] ]
 			: [];
 	}

--- a/src/api/class-jw-player-api.php
+++ b/src/api/class-jw-player-api.php
@@ -44,6 +44,9 @@ class JW_Player_API implements API_Requester {
 
 	/**
 	 * Constructor.
+	 *
+	 * @param string $api_key The API key.
+	 * @param string $api_secret The API secret.
 	 */
 	public function __construct( string $api_key, string $api_secret ) {
 		$this->api_key    = $api_key;
@@ -86,7 +89,7 @@ class JW_Player_API implements API_Requester {
 	 */
 	public function get_request_args(): array {
 		return [
-			'headers'    => [
+			'headers' => [
 				'Authorization' => 'Bearer ' . $this->api_secret,
 				'Content-Type'  => 'application/json',
 			],
@@ -96,7 +99,7 @@ class JW_Player_API implements API_Requester {
 	/**
 	 * Parse the API error response.
 	 *
-	 * @param mixed $response_object The API response object.
+	 * @param array $response_object The API response object.
 	 *
 	 * @return array
 	 */
@@ -109,7 +112,7 @@ class JW_Player_API implements API_Requester {
 	/**
 	 * Parse the API successful response.
 	 *
-	 * @param mixed $response_object The API response object.
+	 * @param array $response_object The API response object.
 	 *
 	 * @return array
 	 */

--- a/src/api/class-jw-player-api.php
+++ b/src/api/class-jw-player-api.php
@@ -79,17 +79,13 @@ class JW_Player_API {
 	 * @return array
 	 */
 	public function request_args( string $type = '' ): array {
-		$default_args = [
+		return [
 			'user-agent' => $this->user_agent(),
 			'headers'    => [
 				'Authorization' => 'Bearer ' . $this->api_secret,
 				'Content-Type'  => 'application/json',
 			],
 		];
-
-		return 'vip' === $type
-			? $default_args
-			: array_merge( $default_args, [ 'timeout' => 3 ] );
 	}
 
 	/**
@@ -147,12 +143,17 @@ class JW_Player_API {
 				3,
 				5,
 				3,
-				$this->request_args( 'vip' )
+				$this->request_args()
 			);
 		} else {
 			$api_request = wp_remote_get(
 				$request_url,
-				$this->request_args()
+				wp_parse_args(
+					$this->request_args(),
+					[
+						'timeout' => 3,
+					]
+				)
 			);
 		}
 

--- a/src/api/class-jw-player-api.php
+++ b/src/api/class-jw-player-api.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * WP Video Sync: JW Player API integration.
+ *
+ * @package wp-video-sync
+ */
+
+namespace Alley\WP\WP_Video_Sync\API;
+
+class JW_Player_API {
+
+	/**
+	 * The API URL.
+	 *
+	 * @var string
+	 */
+	public string $api_url = 'https://api.jwplayer.com/v2/sites';
+
+	/**
+	 * The API public key.
+	 *
+	 * @var string
+	 */
+	public string $api_key;
+
+	/**
+	 * The API v2 secret key.
+	 *
+	 * @var string
+	 */
+	public string $api_secret;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct( string $api_key, string $api_secret ) {
+		$this->api_key    = $api_key;
+		$this->api_secret = $api_secret;
+	}
+
+	/**
+	 * Set the user agent in the request headers for identification purposes.
+	 *
+	 * @return string
+	 */
+	public function user_agent(): string {
+		global $wp_version;
+
+		return 'WordPress/' . $wp_version . ' WPVideoSync/' . WP_VIDEO_SYNC_VERSION . ' PHP/' . phpversion();
+	}
+
+	/**
+	 * Generate the request URL.
+	 *
+	 * @param string $last_modified_date The date of the last modification to the last batch of videos.
+	 * @param int    $batch_size         The number of videos to fetch in each batch.
+	 *
+	 * @return string
+	 */
+	public function request_url( string $last_modified_date, int $batch_size ): string {
+		$request_url = $this->api_url . '/' . $this->api_key . '/media/';
+
+		return add_query_arg(
+			[
+				'q'           => 'last_modified:[' . $last_modified_date . ' TO *]',
+				'page'        => 1,
+				'sort'        => 'last_modified:asc',
+				'page_length' => $batch_size,
+			],
+			$request_url
+		);
+	}
+
+	/**
+	 * Generate the request arguments.
+	 *
+	 * @param string $type The type of request to make.
+	 *
+	 * @return array
+	 */
+	public function request_args( string $type = '' ): array {
+		$default_args = [
+			'user-agent' => $this->user_agent(),
+			'headers'    => [
+				'Authorization' => 'Bearer ' . $this->api_secret,
+				'Content-Type'  => 'application/json',
+			],
+		];
+
+		return 'vip' === $type
+			? $default_args
+			: array_merge( $default_args, [ 'timeout' => 3 ] );
+	}
+
+	/**
+	 * Parse the API response.
+	 *
+	 * @param mixed $api_response The API response.
+	 *
+	 * @return array
+	 */
+	public function parse_response( mixed $api_response ): array {
+		// Failed request expressed as a WP_Error.
+		if ( is_wp_error( $api_response ) ) {
+			return [];
+		}
+
+		// Condition for when the response body is empty.
+		$response_body = wp_remote_retrieve_body( $api_response );
+
+		if ( empty( $response_body ) ) {
+			return [];
+		}
+
+		// Assign the response object for further evaluation.
+		$response_object = json_decode( $response_body );
+
+		if ( 200 !== wp_remote_retrieve_response_code( $api_response ) ) {
+			return isset( $response_object->errors[0]->description )
+				? [ 'error' => $response_object->errors[0]->description ]
+				: [];
+		}
+
+		return is_array( $response_object->media ) && ! empty( $response_object->media )
+			? $response_object->media
+			: [];
+	}
+
+	/**
+	 * Make the API request.
+	 *
+	 * @param string $updated_after The date of the last modification to the last batch of videos.
+	 * @param int    $batch_size    The number of videos to fetch in each batch.
+	 *
+	 * @return array
+	 */
+	public function request_latest_videos( string $updated_after, int $batch_size ): array {
+		$request_url = $this->request_url(
+			$updated_after,
+			$batch_size
+		);
+
+		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
+			$api_request = vip_safe_wp_remote_get(
+				$request_url,
+				'',
+				3,
+				5,
+				3,
+				$this->request_args( 'vip' )
+			);
+		} else {
+			$api_request = wp_remote_get(
+				$request_url,
+				$this->request_args()
+			);
+		}
+
+		return $this->parse_response( $api_request );
+	}
+}

--- a/src/api/class-jw-player-api.php
+++ b/src/api/class-jw-player-api.php
@@ -8,11 +8,13 @@
 namespace Alley\WP\WP_Video_Sync\API;
 
 use Alley\WP\WP_Video_Sync\Interfaces\API_Requester;
+use Alley\WP\WP_Video_Sync\Last_Modified_Date;
+use DateTimeImmutable;
 
 /**
  * JW Player API.
  */
-class JW_Player_API implements API_Requester {
+class JW_Player_API extends Last_Modified_Date implements API_Requester {
 
 	/**
 	 * The API URL.
@@ -80,6 +82,25 @@ class JW_Player_API implements API_Requester {
 				'Content-Type'  => 'application/json',
 			],
 		];
+	}
+
+	/**
+	 * Fetches videos from JW Player that were modified after the provided DateTime.
+	 *
+	 * @param DateTimeImmutable $updated_after Return videos modified after this date.
+	 * @param int               $batch_size    The number of videos to fetch in each batch.
+	 *
+	 * @return array<mixed> An array of video data objects.
+	 */
+	public function get_videos_after( DateTimeImmutable $updated_after, int $batch_size ): array {
+		// Set the request URL based on the arguments.
+		$this->set_request_url(
+			$updated_after->format( 'Y-m-d' ),
+			$batch_size
+		);
+
+		// Perform the request.
+		return ( new Request( $this ) )->get();
 	}
 
 	/**

--- a/src/api/class-request.php
+++ b/src/api/class-request.php
@@ -44,7 +44,7 @@ class Request {
 	/**
 	 * Get the request arguments.
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	public function get_request_args(): array {
 		$requester_args = $this->api_requester->get_request_args();
@@ -53,6 +53,11 @@ class Request {
 			$requester_args['user-agent'] = $this->user_agent();
 		}
 
+		/**
+		 * Allow the request arguments to be filtered before the request is made.
+		 *
+		 * @param array<string, string|float|int|bool|array> $requester_args The request arguments.
+		 */
 		return apply_filters( 'wp_video_sync_request_args', $requester_args );
 	}
 
@@ -60,11 +65,12 @@ class Request {
 	 * Parse the API response.
 	 *
 	 * @param mixed $response The API response.
-	 * @return array
+	 *
+	 * @return array<string, mixed>
 	 */
 	private function parse_response( mixed $response ): array {
 		// Failed request expressed as a WP_Error.
-		if ( is_wp_error( $response ) || empty( $response ) ) {
+		if ( is_wp_error( $response ) || empty( $response ) || ! is_array( $response ) ) {
 			return [];
 		}
 
@@ -87,7 +93,7 @@ class Request {
 	/**
 	 * Perform a GET request.
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	public function get(): array {
 		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {

--- a/src/api/class-request.php
+++ b/src/api/class-request.php
@@ -9,6 +9,9 @@ namespace Alley\WP\WP_Video_Sync\API;
 
 use Alley\WP\WP_Video_Sync\Interfaces\API_Requester;
 
+/**
+ * Perform an API request.
+ */
 class Request {
 
 	/**
@@ -25,8 +28,6 @@ class Request {
 	 */
 	public function __construct( API_Requester $api_requester ) {
 		$this->api_requester = $api_requester;
-
-		return $this;
 	}
 
 	/**
@@ -58,7 +59,7 @@ class Request {
 	/**
 	 * Parse the API response.
 	 *
-	 * @param mixed $response
+	 * @param mixed $response The API response.
 	 * @return array
 	 */
 	private function parse_response( mixed $response ): array {
@@ -99,7 +100,7 @@ class Request {
 				$this->get_request_args()
 			);
 		} else {
-			$api_request = wp_remote_get(
+			$api_request = wp_remote_get( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 				$this->api_requester->get_request_url(),
 				$this->get_request_args()
 			);

--- a/src/api/class-request.php
+++ b/src/api/class-request.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * WP Video Sync: API request integration.
+ *
+ * @package wp-video-sync
+ */
+
+namespace Alley\WP\WP_Video_Sync\API;
+
+use Alley\WP\WP_Video_Sync\Interfaces\API_Requester;
+
+class Request {
+
+	/**
+	 * The API requester.
+	 *
+	 * @var API_Requester
+	 */
+	public API_Requester $api_requester;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param API_Requester $api_requester The API requester.
+	 */
+	public function __construct( API_Requester $api_requester ) {
+		$this->api_requester = $api_requester;
+
+		return $this;
+	}
+
+	/**
+	 * Set the user agent in the request headers for identification purposes.
+	 *
+	 * @return string
+	 */
+	public function user_agent(): string {
+		global $wp_version;
+
+		return 'WordPress/' . $wp_version . ' WPVideoSync/' . WP_VIDEO_SYNC_VERSION . ' PHP/' . phpversion();
+	}
+
+	/**
+	 * Get the request arguments.
+	 *
+	 * @return array
+	 */
+	public function get_request_args(): array {
+		$requester_args = $this->api_requester->get_request_args();
+
+		if ( empty( $requester_args['user-agent'] ) ) {
+			$requester_args['user-agent'] = $this->user_agent();
+		}
+
+		return apply_filters( 'wp_video_sync_request_args', $requester_args );
+	}
+
+	/**
+	 * Parse the API response.
+	 *
+	 * @param mixed $response
+	 * @return array
+	 */
+	private function parse_response( mixed $response ): array {
+		// Failed request expressed as a WP_Error.
+		if ( is_wp_error( $response ) || empty( $response ) ) {
+			return [];
+		}
+
+		// Condition for when the response body is empty.
+		$response_body = wp_remote_retrieve_body( $response );
+
+		if ( empty( $response_body ) ) {
+			return [];
+		}
+
+		// Assign the response object for further evaluation.
+		$response_object = (array) json_decode( $response_body );
+
+		// Explicitly state the results based on response code.
+		return 200 === wp_remote_retrieve_response_code( $response )
+			? $this->api_requester->parse_success( $response_object )
+			: $this->api_requester->parse_error( $response_object );
+	}
+
+	/**
+	 * Perform a GET request.
+	 *
+	 * @return array
+	 */
+	public function get(): array {
+		if ( function_exists( 'vip_safe_wp_remote_get' ) ) {
+			$api_request = vip_safe_wp_remote_get(
+				$this->api_requester->get_request_url(),
+				'',
+				3,
+				5,
+				3,
+				$this->get_request_args()
+			);
+		} else {
+			$api_request = wp_remote_get(
+				$this->api_requester->get_request_url(),
+				$this->get_request_args()
+			);
+		}
+
+		return $this->parse_response( $api_request );
+	}
+}

--- a/src/api/class-request.php
+++ b/src/api/class-request.php
@@ -15,20 +15,11 @@ use Alley\WP\WP_Video_Sync\Interfaces\API_Requester;
 class Request {
 
 	/**
-	 * The API requester.
-	 *
-	 * @var API_Requester
-	 */
-	public API_Requester $api_requester;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param API_Requester $api_requester The API requester.
+	 * @param API_Requester $api_requester Instance of the API requester.
 	 */
-	public function __construct( API_Requester $api_requester ) {
-		$this->api_requester = $api_requester;
-	}
+	public function __construct( public readonly API_Requester $api_requester ) {}
 
 	/**
 	 * Set the user agent in the request headers for identification purposes.

--- a/src/api/class-request.php
+++ b/src/api/class-request.php
@@ -106,9 +106,43 @@ class Request {
 				$this->get_request_args()
 			);
 		} else {
+			// Get the base request arguments.
+			$custom_args = $this->get_request_args();
+
+			// Explicitly define the request arguments.
+			// NOTE: this is addressing an error stemming from PHPStan where the passed arguments to the `wp_remote_get()` were not accepted.
+			$request_args = [];
+
+			// Request method.
+			if ( ! empty( $custom_args['method'] ) && is_string( $custom_args['method'] ) ) {
+				$request_args['method'] = $custom_args['method'];
+			}
+
+			// Request headers.
+			if (
+				! empty( $custom_args['headers'] )
+				&& (
+					is_string( $custom_args['headers'] )
+					|| is_array( $custom_args['headers'] )
+				)
+			) {
+				$request_args['headers'] = $custom_args['headers'];
+			}
+
+			// Request timeout.
+			if ( ! empty( $custom_args['timeout'] ) && is_float( $custom_args['timeout'] ) ) {
+				$request_args['timeout'] = $custom_args['timeout'];
+			}
+
+			// Request user agent.
+			if ( ! empty( $custom_args['user-agent'] ) && is_string( $custom_args['user-agent'] ) ) {
+				$request_args['user-agent'] = $custom_args['user-agent'];
+			}
+
+			// Perform the request.
 			$api_request = wp_remote_get( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
 				$this->api_requester->get_request_url(),
-				$this->get_request_args()
+				array_filter( $request_args )
 			);
 		}
 

--- a/src/class-last-modified-date.php
+++ b/src/class-last-modified-date.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WP_Video_Sync: Last modified date.
+ *
+ * @package wp-video-sync
+ */
+
+namespace Alley\WP\WP_Video_Sync;
+
+use DateTimeImmutable;
+
+/**
+ * Class for tracking the modified date of the last video in a batch.
+ */
+class Last_Modified_Date {
+
+	/**
+	 * The date of the last modification to the last batch of videos.
+	 *
+	 * @var ?DateTimeImmutable
+	 */
+	private ?DateTimeImmutable $last_modified_date = null;
+
+	/**
+	 * Fetches the date of the last modification to the last batch of videos.
+	 *
+	 * @return ?DateTimeImmutable
+	 */
+	public function get_last_modified_date(): ?DateTimeImmutable {
+		return $this->last_modified_date;
+	}
+
+	/**
+	 * Sets the date of the last modification based on the latest batch of videos.
+	 *
+	 * @param string $last_modified_date The date of the last modified video in the batch.
+	 * @return void
+	 */
+	public function set_last_modified_date( string $last_modified_date = '' ): void {
+		$last_modified_date = DateTimeImmutable::createFromFormat( DATE_W3C, $last_modified_date );
+
+		if ( $last_modified_date instanceof \DateTimeImmutable ) {
+			$this->last_modified_date = $last_modified_date;
+		}
+	}
+}

--- a/src/class-last-modified-date.php
+++ b/src/class-last-modified-date.php
@@ -33,14 +33,10 @@ class Last_Modified_Date {
 	/**
 	 * Sets the date of the last modification based on the latest batch of videos.
 	 *
-	 * @param string $last_modified_date The date of the last modified video in the batch.
+	 * @param DateTimeImmutable $last_modified_date The date of the last modified video in the batch.
 	 * @return void
 	 */
-	public function set_last_modified_date( string $last_modified_date = '' ): void {
-		$last_modified_date = DateTimeImmutable::createFromFormat( DATE_W3C, $last_modified_date );
-
-		if ( $last_modified_date instanceof \DateTimeImmutable ) {
-			$this->last_modified_date = $last_modified_date;
-		}
+	public function set_last_modified_date( DateTimeImmutable $last_modified_date ): void {
+		$this->last_modified_date = $last_modified_date;
 	}
 }

--- a/src/class-sync-manager.php
+++ b/src/class-sync-manager.php
@@ -113,9 +113,11 @@ class Sync_Manager {
 		}
 
 		// Try to update the last sync time to the last modified time of the last video that was processed.
-		$next_last_modified = $this->adapter->get_last_modified_date();
-		if ( $next_last_modified instanceof DateTimeImmutable ) {
-			update_option( self::LAST_SYNC_OPTION, $next_last_modified->format( DATE_W3C ), false );
+		if ( method_exists( $this->adapter, 'get_last_modified_date' ) ) {
+			$next_last_modified = $this->adapter->get_last_modified_date();
+			if ( $next_last_modified instanceof DateTimeImmutable ) {
+				update_option( self::LAST_SYNC_OPTION, $next_last_modified->format( DATE_W3C ), false );
+			}
 		}
 	}
 

--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -1,0 +1,7 @@
+## Class Adapter
+
+Adhere to the Adapter interface to create a new adapter for syncing videos.
+
+## Class API_Request
+
+Adhere to the API_Request interface to provide the necesssary methods for making and processing an API request.

--- a/src/interfaces/adapter.php
+++ b/src/interfaces/adapter.php
@@ -14,12 +14,6 @@ use stdClass;
  * Defines an interface that all adapters must implement.
  */
 interface Adapter {
-	/**
-	 * Fetches the date of the last modification to the last batch of videos.
-	 *
-	 * @return ?DateTimeImmutable
-	 */
-	public function get_last_modified_date(): ?DateTimeImmutable;
 
 	/**
 	 * Fetches videos from the provider that were modified after the provided DateTime.

--- a/src/interfaces/adapter.php
+++ b/src/interfaces/adapter.php
@@ -15,6 +15,13 @@ use DateTimeImmutable;
 interface Adapter {
 
 	/**
+	 * Fetches the date of the last modification to the last batch of videos.
+	 *
+	 * @return ?DateTimeImmutable
+	 */
+	public function get_last_modified_date(): ?DateTimeImmutable;
+
+	/**
 	 * Fetches videos from the provider that were modified after the provided DateTime.
 	 *
 	 * @param DateTimeImmutable $updated_after Return videos modified after this date.

--- a/src/interfaces/adapter.php
+++ b/src/interfaces/adapter.php
@@ -8,7 +8,6 @@
 namespace Alley\WP\WP_Video_Sync\Interfaces;
 
 use DateTimeImmutable;
-use stdClass;
 
 /**
  * Defines an interface that all adapters must implement.
@@ -21,7 +20,7 @@ interface Adapter {
 	 * @param DateTimeImmutable $updated_after Return videos modified after this date.
 	 * @param int               $batch_size    The number of videos to fetch in each batch.
 	 *
-	 * @return stdClass[] An array of video data. Specific shape will be determined by the adapter.
+	 * @return array<mixed> An array of video data. Specific shape will be determined by the adapter.
 	 */
 	public function get_videos( DateTimeImmutable $updated_after, int $batch_size ): array;
 }

--- a/src/interfaces/api-requester.php
+++ b/src/interfaces/api-requester.php
@@ -44,5 +44,4 @@ interface API_Requester {
 	 * @return array<string, mixed>
 	 */
 	public function parse_success( array $response_object ): array;
-
 }

--- a/src/interfaces/api-requester.php
+++ b/src/interfaces/api-requester.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WP Video Sync: API Requester Interface
+ *
+ * @package wp-video-sync
+ */
+
+namespace Alley\WP\WP_Video_Sync\Interfaces;
+
+/**
+ * Defines an interface that all adapters must implement to
+ * perform API requests that interact with `Request` class.
+ */
+interface API_Requester {
+
+	/**
+	 * Get the URL for the API request.
+	 *
+	 * @return string
+	 */
+	public function get_request_url(): string;
+
+	/**
+	 * Get the arguments for the API request.
+	 *
+	 * @return array
+	 */
+	public function get_request_args(): array;
+
+	/**
+	 * Parse a successful API response.
+	 *
+	 * @param array $response_object The response object.
+	 * @return array
+	 */
+	public function parse_success( array $response_object ): array;
+
+	/**
+	 * Parse an error API response.
+	 *
+	 * @param array $response_object The response object.
+	 * @return array
+	 */
+	public function parse_error( array $response_object ): array;
+}

--- a/src/interfaces/api-requester.php
+++ b/src/interfaces/api-requester.php
@@ -23,23 +23,26 @@ interface API_Requester {
 	/**
 	 * Get the arguments for the API request.
 	 *
-	 * @return array
+	 * @return array<string, array<string, string>>
 	 */
 	public function get_request_args(): array;
 
 	/**
+	 * Parse an error API response.
+	 *
+	 * @param array<mixed> $response_object The API response object.
+	 *
+	 * @return array<string, string>
+	 */
+	public function parse_error( array $response_object ): array;
+
+	/**
 	 * Parse a successful API response.
 	 *
-	 * @param array $response_object The response object.
-	 * @return array
+	 * @param array<mixed> $response_object The API response object.
+	 *
+	 * @return array<string, mixed>
 	 */
 	public function parse_success( array $response_object ): array;
 
-	/**
-	 * Parse an error API response.
-	 *
-	 * @param array $response_object The response object.
-	 * @return array
-	 */
-	public function parse_error( array $response_object ): array;
 }

--- a/tests/Feature/JWPlayer7ForWPAdapterTest.php
+++ b/tests/Feature/JWPlayer7ForWPAdapterTest.php
@@ -1,40 +1,37 @@
 <?php
 /**
- * WP Video Sync Tests: JW Player Adapter Test
+ * WP Video Sync Tests: JW Player 7 for WP Adapter Test.
  *
  * @package wp-video-sync
  */
 
 namespace Alley\WP\WP_Video_Sync\Tests\Feature;
 
-use Alley\WP\WP_Video_Sync\API\JW_Player_API;
-use Alley\WP\WP_Video_Sync\Adapters\JW_Player;
+use Alley\WP\WP_Video_Sync\Adapters\JW_Player_7_For_WP;
 use Alley\WP\WP_Video_Sync\Sync_Manager;
 use Alley\WP\WP_Video_Sync\Tests\TestCase;
 use DateTimeImmutable;
 use WP_Query;
 
 /**
- * A test suite for the JW Player adapter.
+ * A test suite for the JW Player 7 for WP adapter.
  */
-class JWPlayerAdapterTest extends TestCase {
-
+class JWPlayer7ForWPAdapterTest extends TestCase {
 	/**
-	 * Tests the behavior of the adapter with the JW Player.
+	 * Tests the behavior of the adapter with the JW Player 7 for WP plugin (free and premium).
 	 */
-	public function test_jw_player() {
+	public function test_jw_player_7_for_wp() {
+		// Fake the class that's used to make the API call.
+		require_once __DIR__ . '/../Mocks/JWPPP_Dashboard_API.php';
+
 		// Fake the API response for the first page of data.
-		$this->fake_request( 'https://api.jwplayer.com/v2/sites/api_key/media*' )
+		$this->fake_request( 'https://api.jwplayer.com/v2/sites/example-api-key/media/*' )
 			->with_response_code( 200 )
-			->with_file( __DIR__ . '/../Fixtures/jw-player-api-v2-media.json' );
+			->with_body( file_get_contents( __DIR__ . '/../Fixtures/jw-player-api-v2-media.json' ) );
 
 		// Create an instance of the adapter.
 		$sync_manager = Sync_Manager::init()
-			->with_adapter(
-				new JW_Player(
-					new JW_Player_API( 'api_key', 'api_secret' )
-				)
-			)
+			->with_adapter( new JW_Player_7_For_WP() )
 			->with_callback( fn ( $video ) => self::factory()->post->create(
 				[
 					'post_title'    => $video->metadata->title,
@@ -57,7 +54,6 @@ class JWPlayerAdapterTest extends TestCase {
 				'post_type'   => 'post',
 			]
 		);
-
 		$this->assertEquals( 1, $video_query->post_count );
 		$this->assertEquals( 'Example Video', $video_query->posts[0]->post_title );
 		$this->assertEquals( '2024-01-01 12:00:00', $video_query->posts[0]->post_date );

--- a/tests/Feature/JWPlayerAdapterTest.php
+++ b/tests/Feature/JWPlayerAdapterTest.php
@@ -32,7 +32,8 @@ class JWPlayerAdapterTest extends TestCase {
 		$sync_manager = Sync_Manager::init()
 			->with_adapter(
 				new JW_Player(
-					new JW_Player_API( 'api_key', 'api_secret' )
+					'api_key',
+					'api_secret'
 				)
 			)
 			->with_callback( fn ( $video ) => self::factory()->post->create(

--- a/wp-video-sync.php
+++ b/wp-video-sync.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Video Sync
  * Plugin URI: https://github.com/alleyinteractive/wp-video-sync
  * Description: Sync videos from a hosting provider to WordPress
- * Version: 0.1.0
+ * Version: 0.2.0
  * Author: Alley
  * Author URI: https://github.com/alleyinteractive/wp-video-sync
  * Requires at least: 6.0
@@ -22,6 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define the plugin version.
-define( 'WP_VIDEO_SYNC_VERSION', '1.7.2' );
+define( 'WP_VIDEO_SYNC_VERSION', '0.2.0' );
 
 require_once __DIR__ . '/src/autoload.php';

--- a/wp-video-sync.php
+++ b/wp-video-sync.php
@@ -21,4 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// Define the plugin version.
+define( 'WP_VIDEO_SYNC_VERSION', '1.7.2' );
+
 require_once __DIR__ . '/src/autoload.php';


### PR DESCRIPTION
**`src/api/class-jw-player-api.php`:** This class is to handle the API logic for performing a request to the JWPlayer API and handle the responses.

> [!NOTE]
> I had to update the function `get_last_modified_date()` because `$this->last_modified_date` was throwing a PHP error (Typed property must not be accessed before initialization) which I believe was due to the option of the last modified date not existing. I thought I would mention as I wasn't sure why this is different than what is in the `class-jw-player-7-for-wp.php` file.

**`src/adapters/class-jw-player.php`:** This is the Adapter used for syncing the posts. This class is instantiated with the `JW_Player_API` class - this could be changed to be accepting a class that is adhering to an Interface, but it doesn't seem necessary at this beginning stage.

**`WP_VIDEO_SYNC_VERSION`:** This constant was added so it may be output as the user agent in the header.